### PR TITLE
Specify row_privacy in the PUMS metadata

### DIFF
--- a/data/extending/README.md
+++ b/data/extending/README.md
@@ -4,7 +4,7 @@ PrivateReader operates by intercepting SQL requests to a Reader implementation,
 rewriting the SQL where necessary, then post-processing the results to add
 differentially private noise.  It may work automatically with many SQL-92
 sources, but you may want to make custom Reader implementations to handle
-custom connection behavior, or engine-specific semantics
+custom connection behavior, or engine-specific semantics.
 
 ## Creating a DataReader
 
@@ -13,10 +13,10 @@ engine and returns results in the form of a list of tuples.  This is the
 default behavior for ODBC and DBAPI on Python.
 
 ```python
-from burdock.reader.sql.base import Reader, NameCompare
+from opendp.whitenoise.sql.reader.sql_base import SqlReader, NameCompare
 from my.engine import my_api
 
-class MyEngineReader(Reader):
+class MyEngineReader(SqlReader):
     def __init__(self, gateway, catalog, credentials):
         self.gateway = gateway
         self.catalog = catalog
@@ -53,7 +53,8 @@ Your main code goes in the `execute` method.  The execute method takes a query a
 To use the reader you created, plug it in just like any other Reader:
 
 ```python
-from burdock.sql import PrivateReader, CollectionMetadata
+from opendp.whitenoise.sql.private_reader import PrivateReader
+from opendp.whitenoise.metadata import CollectionMetadata
 from my.engine.reader import MyEngineReader
 
 meta = CollectionMetadata.from_file('Sales.yaml')

--- a/data/extending/README.md
+++ b/data/extending/README.md
@@ -1,15 +1,15 @@
 # Extending the Data Access APIs
 
-PrivateReader operates by intercepting SQL requests to a Reader implementaion,
+PrivateReader operates by intercepting SQL requests to a Reader implementation,
 rewriting the SQL where necessary, then post-processing the results to add
-differntially private noise.  It may work automatically with many SQL-92
+differentially private noise.  It may work automatically with many SQL-92
 sources, but you may want to mke custom Reader implementations to handle
 custom connection behavior, or engine-specific semantics
 
 ## Creating a DataReader
 
 A data reader is just a pipe that sends SQL to some sort of data processing
-engine and returs results in the form of a list of tuples.  This is the 
+engine and returns results in the form of a list of tuples.  This is the 
 default behavior for ODBC and DBAPI on Python.
 
 ```python
@@ -38,15 +38,15 @@ class MyEngineSerializer:
         return sql.replace('RANDOM', 'rand')
 ```
 
-To implement a Reader, you need to ingerit from the base Reader, and be sure to set the `engine` property.
+To implement a Reader, you need to inherit from the base Reader, and be sure to set the `engine` property.
 
 The constructor can have any setup paramaters that your engine needs.  In this example, we are passing in connection string information needed to connect to a gateway, but you could also have your callers set up some sort of session outside the reader and pass it in.
 
-If you don't need specialized handling for case-sensitive or escaped identifiers, you can omit the specilization of NameCompare, and the base Reader will automatically give you a base NameCompare that is case-sensitivie.
+If you don't need specialized handling for case-sensitive or escaped identifiers, you can omit the specialization of NameCompare, and the base Reader will automatically give you a base NameCompare that is case-sensitive.
 
-If your engine uses a dialect of SQL that we don't support, you can provide a serializer to automatically fix the dialect befre sending to the engine.
+If your engine uses a dialect of SQL that we don't support, you can provide a serializer to automatically fix the dialect before sending to the engine.
 
-Your main code goes in the `execute` method.  The execute method takes a query as a string, and returns a list of tuples, with the firt tuple being column names, and each following tuple representing a row of values.  The base reader provides other methods that allow compiled ASTs to be executed, and to return TypedRowset objects.
+Your main code goes in the `execute` method.  The execute method takes a query as a string, and returns a list of tuples, with the first tuple being column names, and each following tuple representing a row of values.  The base reader provides other methods that allow compiled ASTs to be executed, and to return TypedRowset objects.
 
 ## Using the Reader
 

--- a/data/extending/README.md
+++ b/data/extending/README.md
@@ -3,13 +3,13 @@
 PrivateReader operates by intercepting SQL requests to a Reader implementation,
 rewriting the SQL where necessary, then post-processing the results to add
 differentially private noise.  It may work automatically with many SQL-92
-sources, but you may want to mke custom Reader implementations to handle
+sources, but you may want to make custom Reader implementations to handle
 custom connection behavior, or engine-specific semantics
 
 ## Creating a DataReader
 
 A data reader is just a pipe that sends SQL to some sort of data processing
-engine and returns results in the form of a list of tuples.  This is the 
+engine and returns results in the form of a list of tuples.  This is the
 default behavior for ODBC and DBAPI on Python.
 
 ```python

--- a/data/readers/PUMS.yaml
+++ b/data/readers/PUMS.yaml
@@ -1,6 +1,7 @@
 Database:
   PUMS:
     PUMS:
+      row_privacy: True
       rows: 1000
       age:
         type: int

--- a/data/readers/PUMS_large.yaml
+++ b/data/readers/PUMS_large.yaml
@@ -1,6 +1,7 @@
 Collection:
   PUMS:
     PUMS_large:
+      row_privacy: True
       PersonID:
         type: int
         private_id: true


### PR DESCRIPTION
The PUMS files do not need reservoir sampling, since they have row privacy set.  Specifying in the metadata allows sample queries to run without the overhead of sampling