### PR TITLE
Fix mislabeled epsilon

### DIFF
--- a/analysis/tutorial_mental_health_in_tech_survey.ipynb
+++ b/analysis/tutorial_mental_health_in_tech_survey.ipynb
@@ -498,7 +498,7 @@
    "source": [
     "age_true = [478, 554, 149, 26, 6]\n",
     "age_geo = age_histogram.value\n",
-    "epsilon_ = 0.01\n",
+    "epsilon_ = 0.1\n",
     "age_labels = ['21-30 years', '30-39 years', '40-49 years',\n",
     "         '50-59 years', '60+ years']\n",
     "title = 'Comparison of Results: Geometric Mechanism - epsilon '+str(epsilon_)\n",
@@ -533,7 +533,7 @@
    "source": [
     "country_true = [ 240, 732, 175, 66]\n",
     "country_geo = country_histogram.value\n",
-    "epsilon_ = 0.01\n",
+    "epsilon_ = 0.1\n",
     "country_labels = ['Other','US', 'UK','CA' ]\n",
     "title = 'Comparison of Results: Geometric Mechanism - epsilon '+str(epsilon_)\n",
     "subtitle1 = 'True Counts: Country of Participants'\n",
@@ -567,7 +567,7 @@
    "source": [
     "gender_true = [16, 955, 242]\n",
     "gender_geo = gender_histogram.value\n",
-    "epsilon_ = 0.01\n",
+    "epsilon_ = 0.1\n",
     "gender_labels = ['Non-binary', 'Male', 'Female']\n",
     "title = 'Comparison of Results: Geometric Mechanism - epsilon '+str(epsilon_)\n",
     "subtitle1 = 'True Counts: Gender '\n",
@@ -601,7 +601,7 @@
    "source": [
     "remote_true = [360, 853]\n",
     "remote_geo = remotework_histogram.value\n",
-    "epsilon_ = 0.01\n",
+    "epsilon_ = 0.1\n",
     "remote_labels = ['Does not work remotely', 'Works remotely' ]\n",
     "title = 'Comparison of Results: Geometric Mechanism - epsilon '+str(epsilon_)\n",
     "subtitle1 = 'True Counts: Remote work '\n",
@@ -635,7 +635,7 @@
    "source": [
     "family_true = [480, 733]\n",
     "family_geo = family_histogram.value\n",
-    "epsilon_ = 0.01\n",
+    "epsilon_ = 0.1\n",
     "family_labels = ['Family history of MI','No family history']\n",
     "\n",
     "title = 'Comparison of Results: Geometric Mechanism - epsilon '+str(epsilon_)\n",
@@ -670,7 +670,7 @@
    "source": [
     "treatment_true = [615, 598]\n",
     "treatment_geo = treatment_histogram.value\n",
-    "epsilon_ = 0.01\n",
+    "epsilon_ = 0.1\n",
     "treatment_labels = ['Not Diagnosed','Diagnosed']\n",
     "\n",
     "title = 'Comparison of Results: Geometric Mechanism - epsilon '+str(epsilon_)\n",


### PR DESCRIPTION
The ε value printed next to the pie charts appears wrong. It's set to `0.1` when the private queries are made but reported as `0.01` in the figures.